### PR TITLE
Correct parsing of token

### DIFF
--- a/Samples/csharp_dotnetcore/01.federated-search-provider/SearchSupport/SearchHelper.cs
+++ b/Samples/csharp_dotnetcore/01.federated-search-provider/SearchSupport/SearchHelper.cs
@@ -92,7 +92,7 @@ namespace Microsoft.SearchProvider.Bots
                 {
                     foreach (var a in data.authorizations)
                     {
-                        listOfTokens.Add(JsonConvert.DeserializeObject<SearchBotAuthenticationToken>(JsonConvert.SerializeObject(a)));
+                        listOfTokens.Add(new SearchBotAuthenticationToken((AuthenticationTypes)a.authType, (string)a.token));
                     }
 
                     token = listOfTokens?.Where(item => item.AuthType == AuthenticationTypes.OBOToken).FirstOrDefault();


### PR DESCRIPTION
The token type was being parsed incorrectly from dynamic. Edit it so that it parses correctly.